### PR TITLE
add example usage of todo and remarks block; fix indentation of todo text;

### DIFF
--- a/doxygen-awesome.css
+++ b/doxygen-awesome.css
@@ -1118,7 +1118,7 @@ dl.deprecated dt a {
     color: var(--deprecated-color-dark) !important;
 }
 
-dl.section dd, dl.bug dd, dl.deprecated dd {
+dl.section dd, dl.bug dd, dl.deprecated dd, dl.todo dd {
     margin-inline-start: 0px;
 }
 

--- a/include/MyLibrary/example.hpp
+++ b/include/MyLibrary/example.hpp
@@ -82,7 +82,9 @@ public:
      *
      * @pre This is a precondition
      *
+     * @todo This theme is never finished!
      *
+     * @remark This is awesome!
      *
      */
     std::string test(const std::string& test);


### PR DESCRIPTION
Thanks for your contribution, @briederer ! I've added usage examples for the demo docs and fixed have overwritten the default indentation of the todo text, as I have done it for the other blocks as well.